### PR TITLE
Install dotenv to allow access to .env file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "axios": "^1.2.2",
+        "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "mongoose": "^6.8.3",
         "nodemon": "^2.0.20",
@@ -3717,6 +3718,14 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ee-first": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "axios": "^1.2.2",
+    "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "mongoose": "^6.8.3",
     "nodemon": "^2.0.20",

--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,7 @@ const db = require('./db.js');
 // basic middleware
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+require("dotenv").config();
 
 // will need to get webpack up and running as well as our top level React component in order to see anything in the browser
 app.use(express.static(path.join(__dirname, '../client/dist')));


### PR DESCRIPTION
I ran npm install dotenv --save, which allows me to call in the .env file as process.env.<YOURDATAHERE>. This allows access to the GitHub token.